### PR TITLE
stopAuthentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ await localAuth.authenticateWithBiometrics(
 
 ```
 
+If needed, you can manually stop authentication for android:
+
+```dart
+
+void _cancelAuthentication() {
+    localAuth.stopAuthentication();
+}
+
+```
+
 ### Exceptions
 
 There are 4 types of exceptions: PasscodeNotSet, NotEnrolled, NotAvailable and

--- a/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -113,6 +113,11 @@ class AuthenticationHelper extends FingerprintManagerCompat.AuthenticationCallba
     }
   }
 
+  /** Cancels the fingerprint authentication. */
+  void stopAuthentication() {
+    stop(false);
+  }
+
   private void start() {
     activity.getApplication().registerActivityLifecycleCallbacks(this);
     resume();

--- a/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
+++ b/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class LocalAuthPlugin implements MethodCallHandler {
   private final Registrar registrar;
   private final AtomicBoolean authInProgress = new AtomicBoolean(false);
+  private AuthenticationHelper authenticationHelper;
 
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
@@ -47,7 +48,7 @@ public class LocalAuthPlugin implements MethodCallHandler {
         result.error("no_activity", "local_auth plugin requires a foreground activity", null);
         return;
       }
-      AuthenticationHelper authenticationHelper =
+      authenticationHelper =
           new AuthenticationHelper(
               activity,
               call,
@@ -91,8 +92,27 @@ public class LocalAuthPlugin implements MethodCallHandler {
         result.error("no_biometrics_available", e.getMessage(), null);
       }
 
+    } else if (call.method.equals(("stopAuthentication"))) {
+      stopAuthentication(result);
     } else {
       result.notImplemented();
+    }
+  }
+
+  /*
+   Stops the authentication if in progress.
+  */
+  private void stopAuthentication(Result result) {
+    try {
+      if (authenticationHelper != null && authInProgress.get()) {
+        authenticationHelper.stopAuthentication();
+        authenticationHelper = null;
+        result.success(true);
+        return;
+      }
+      result.success(false);
+    } catch (Exception e) {
+      result.success(false);
     }
   }
 }

--- a/lib/flutter_local_auth_invisible.dart
+++ b/lib/flutter_local_auth_invisible.dart
@@ -97,6 +97,18 @@ class LocalAuthentication {
       (await _channel.invokeListMethod<String>('getAvailableBiometrics'))
           .isNotEmpty;
 
+  /// Returns true if auth was cancelled successfully.
+  /// This api only works for Android.
+  /// Returns false if there was some error or no auth in progress.
+  ///
+  /// Returns [Future] bool true or false:
+  Future<bool> stopAuthentication() {
+    if (_platform.isAndroid) {
+      return _channel.invokeMethod<bool>('stopAuthentication');
+    }
+    return Future<bool>.sync(() => true);
+  }
+
   /// Returns a list of enrolled biometrics
   ///
   /// Returns a [Future] List<BiometricType> with the following possibilities:


### PR DESCRIPTION
The `stopAuthentication` method was implemented. The method allows to cancel the authentication request, like the `stopAuthentication` method from local_auth package. 

The signature of this method is the same signature of `stopAuthentication` method from local_auth package.